### PR TITLE
Update capybara-bootstrap-datepicker.rb

### DIFF
--- a/lib/capybara-bootstrap-datepicker.rb
+++ b/lib/capybara-bootstrap-datepicker.rb
@@ -3,7 +3,7 @@ require 'rspec/core'
 
 module Capybara
   module BootstrapDatepicker
-    def select_date(value, datepicker: :boostrap, format: nil, from: nil, xpath: nil)
+    def select_date(value, datepicker: :bootstrap, format: nil, from: nil, xpath: nil)
       fail "Must pass a hash containing 'from' or 'xpath'" if from.nil? && xpath.nil?
 
       value = Date.parse(value) unless value.respond_to? :to_date


### PR DESCRIPTION
 def select_date(value, datepicker: :boostrap, format: nil, from: nil, xpath: nil)
                                     ^ (SyntaxError)

you should change boostrap to bootstrap
