### PR TITLE
Adds missing argument to simple datepicker.

### DIFF
--- a/lib/capybara-bootstrap-datepicker.rb
+++ b/lib/capybara-bootstrap-datepicker.rb
@@ -21,7 +21,7 @@ module Capybara
       when :bootstrap
         select_bootstrap_date date_input, value
       else
-        select_simple_date date_input, value
+        select_simple_date date_input, value, format
       end
 
       first(:xpath, '//body').click
@@ -30,7 +30,7 @@ module Capybara
     # Selects a date by filling the input field
     # @param date_input the input field
     # @param value [Date] the date to set
-    def select_simple_date(date_input, value)
+    def select_simple_date(date_input, value, format)
       value = value.strftime format if format.present?
 
       date_input.set "#{value}\e"


### PR DESCRIPTION
Hi there, FYI it looks like you forgot to add the format arg to the "simple" method (I think this should be changed into date_format) since format itself is a reserved word, anyway without adding this into the method I couldn't use the library, just keep an eye on that and see if you think this needs to be merged with master. PS. also, looks like that when i use the default :bootstrap option it always fails date validation :(