### PR TITLE
fix Picker#gap returns wrong number

### DIFF
--- a/lib/capybara-bootstrap-datepicker.rb
+++ b/lib/capybara-bootstrap-datepicker.rb
@@ -187,7 +187,7 @@ module Capybara
       # @return [Fixnum] the distance in decades between min and max
       def gap(min, max)
         return 0 if min >= max
-        (max - min) / 10
+        (max - min) / 10 + 1
       end
 
       # Go backward to the wanted decade

--- a/spec/features/bootstrap_datepicker_spec.rb
+++ b/spec/features/bootstrap_datepicker_spec.rb
@@ -23,6 +23,42 @@ RSpec.shared_examples 'a datepicker' do
       select_date DateTime.now, from: 'Label of my date input'
       expect(subject).to eq Date.today
     end
+
+    context 'decade discovery' do
+      let(:current_decade_start) { Date.today.year / 10 * 10 }
+
+      it 'fills in date in previous decade', js: true do
+        # when decade is 2020, date is 2018-01-01
+        date = Date.new(current_decade_start - 2, 1, 1)
+
+        select_date date , from: 'Label of my date input'
+        expect(subject).to eq date
+      end
+
+      it 'fills in date in next decade', js: true do
+        # when decade is 2020, date is 2032-01-01
+        date = Date.new(current_decade_start + 12, 1, 1)
+
+        select_date date , from: 'Label of my date input'
+        expect(subject).to eq date
+      end
+
+      it 'fills in date 3 decades in the past', js: true do
+        # when decade is 2020, date is 1998-01-01
+        date = Date.new(current_decade_start - 22, 1, 1)
+
+        select_date date , from: 'Label of my date input'
+        expect(subject).to eq date
+      end
+
+      it 'fills in date 3 decades in the future', js: true do
+        # when decade is 2020, date is 2052-01-01
+        date = Date.new(current_decade_start + 32, 1, 1)
+
+        select_date date , from: 'Label of my date input'
+        expect(subject).to eq date
+      end
+    end
   end
 
   context 'locale date' do


### PR DESCRIPTION
Hello maintainer,

We've been facing issues with dates in past or future decades using your gem.
Here is the fix we have been required to add as a patch in our project.
What do you think?

When current decade is `2020-2029` and you want to choose a date in past or future decades, for instance `2018-01-01`, it breaks.

### current behavior

```
(2020 - 2018) / 10
=> 0
```

### expected behavior

```
(2020 - 2018) / 10 + 1
=> 1
```

So that `goto_prev_decade` and `goto_next_decade` results in `1` time click on "prev" or "next" button.