### PR TITLE
[breaking change] unobtrusive datepicker interaction

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     capybara-screenshot (1.0.24)
       capybara (>= 1.0, < 4)
       launchy
+    childprocess (3.0.0)
     cliver (0.3.2)
     diff-lcs (1.3)
     launchy (2.4.3)
@@ -50,6 +51,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
+    rubyzip (2.3.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
+    webdrivers (4.4.2)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -68,6 +77,8 @@ DEPENDENCIES
   poltergeist (~> 1.18, >= 1.18.1)
   rack (>= 1.6.11)
   rspec (~> 3.9, >= 3.9.0)
+  selenium-webdriver
+  webdrivers
 
 BUNDLED WITH
    2.1.0

--- a/capybara-bootstrap-datepicker.gemspec
+++ b/capybara-bootstrap-datepicker.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'phantomjs', '~> 2.1', '>= 2.1.1.0'
   gem.add_development_dependency 'poltergeist', '~> 1.18', '>= 1.18.1'
   gem.add_development_dependency 'rspec', '~> 3.9', '>= 3.9.0'
+  gem.add_development_dependency 'webdrivers'
+  gem.add_development_dependency 'selenium-webdriver'
 end

--- a/lib/capybara-bootstrap-datepicker.rb
+++ b/lib/capybara-bootstrap-datepicker.rb
@@ -22,8 +22,6 @@ module Capybara
       else
         select_simple_date date_input, value, format
       end
-
-      first(:xpath, '//body').click
     end
 
     # Selects a date by filling the input field
@@ -49,8 +47,6 @@ module Capybara
       picker.find_year(value.year).click
       picker.find_month(value.month).click
       picker.find_day(value.day).click
-
-      fail if Date.parse(date_input.value) != value
     end
 
     private

--- a/spec/features/bootstrap-3.4.html
+++ b/spec/features/bootstrap-3.4.html
@@ -37,6 +37,14 @@
           <input id="registration-period-start-datapicker" class="form-control" type="text" name="cfp[start_date]">
         </span>
       </div>
+
+      <div class="form-group">
+        <label for="my-date-input-with-callbacks">Label of date input with dialog callback</label>
+        <div class="input-group date my-date-input-with-callbacks">
+          <input type="text" class="form-control" id="my-date-input-with-callbacks">
+          <span class="input-group-addon"><i class="glyphicon glyphicon-th"></i></span>
+        </div>
+      </div>
     </form>
   </div>
   <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
@@ -46,6 +54,10 @@
     $('.input-group.default-date').datepicker({ format: 'yyyy-mm-dd' });
     $('.input-group.locale-date').datepicker({ format: 'yyyy-mm-dd', language: 'ja' });
     $('#registration-period-start-datapicker').datepicker({ format: 'yyyy-mm-dd', minDate : '2019-03-06', maxDate : '2019-03-12' });
+
+    $('.input-group.my-date-input-with-callbacks')
+      .datepicker({ format: 'yyyy-mm-dd' })
+      .on('change', function() { alert('Date has changed') });
   </script>
 </body>
 </html>

--- a/spec/features/bootstrap-4.4.html
+++ b/spec/features/bootstrap-4.4.html
@@ -37,6 +37,14 @@
           <input id="registration-period-start-datapicker" class="form-control" type="text" name="cfp[start_date]">
         </span>
       </div>
+
+      <div class="form-group">
+        <label for="my-date-input-with-callbacks">Label of date input with dialog callback</label>
+        <div class="input-group date my-date-input-with-callbacks">
+          <input type="text" class="form-control" id="my-date-input-with-callbacks">
+          <span class="input-group-addon"><i class="glyphicon glyphicon-th"></i></span>
+        </div>
+      </div>
     </form>
   </div>
   <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
@@ -51,6 +59,10 @@
       minDate : '2019-03-06',
       maxDate : '2019-03-12'
     });
+
+    $('.input-group.my-date-input-with-callbacks')
+      .datepicker({ format: 'yyyy-mm-dd' })
+      .on('change', function() { alert('Date has changed') });
   </script>
 </body>
 </html>

--- a/spec/features/bootstrap_datepicker_spec.rb
+++ b/spec/features/bootstrap_datepicker_spec.rb
@@ -42,30 +42,59 @@ RSpec.shared_examples 'a datepicker' do
       expect(subject).to eq Date.today
     end
   end
+
+  context 'dialog callback' do
+    subject { Date.parse(find_field('Label of date input with dialog callback').value) }
+
+    it 'fills in a datepicker while passing alert dialog', js: true do
+      accept_alert 'Date has changed' do
+        select_date Date.today, from: 'Label of date input with dialog callback', datepicker: :simple
+        first(:xpath, '//body').click
+      end
+
+      expect(subject).to eq Date.today
+    end
+
+    it 'fills in a datepicker while passing alert dialog on Bootstrap', js: true do
+      accept_alert 'Date has changed' do
+        select_date Date.today, from: 'Label of date input with dialog callback', datepicker: :bootstrap
+      end
+
+      expect(subject).to eq Date.today
+    end
+  end
 end
 
 RSpec.describe 'Bootstrap Datepicker', type: :feature do
-  describe 'Boostrap 3.4' do
-    before :each do
-      Capybara.current_session.driver.visit "#{Capybara.app_host}/bootstrap-3.4.html"
+  [:poltergeist, :selenium_chrome_headless].each do |driver|
+    context "with #{driver}" do
+      before do
+        Capybara.current_driver = driver
+      end
+
+      describe 'Boostrap 3.4' do
+        before :each do
+          Capybara.current_session.driver.visit "#{Capybara.app_host}/bootstrap-3.4.html"
+        end
+
+        it 'loads the page correctly', js: true do
+          expect(page).to have_content 'Bootstrap 3.4 Datepicker'
+        end
+
+        it_behaves_like 'a datepicker'
+      end
+
+      describe 'Boostrap 4.4' do
+        before :each do
+          Capybara.current_session.driver.visit "#{Capybara.app_host}/bootstrap-4.4.html"
+        end
+
+        it 'loads the page correctly', js: true do
+          expect(page).to have_content 'Bootstrap 4.4 Datepicker'
+        end
+
+        it_behaves_like 'a datepicker'
+      end
     end
-
-    it 'loads the page correctly', js: true do
-      expect(page).to have_content 'Bootstrap 3.4 Datepicker'
-    end
-
-    it_behaves_like 'a datepicker'
-  end
-
-  describe 'Boostrap 4.4' do
-    before :each do
-      Capybara.current_session.driver.visit "#{Capybara.app_host}/bootstrap-4.4.html"
-    end
-
-    it 'loads the page correctly', js: true do
-      expect(page).to have_content 'Bootstrap 4.4 Datepicker'
-    end
-
-    it_behaves_like 'a datepicker'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ require 'capybara/rspec'
 require 'capybara-screenshot/rspec'
 require 'capybara/poltergeist'
 require 'phantomjs/poltergeist'
+require 'webdrivers/chromedriver'
+require 'selenium/webdriver'
 
 Capybara.configure do |config|
   config.javascript_driver = :poltergeist


### PR DESCRIPTION
Dear maintainer,

In our project we are using Capybara Selenium with Chrome browser.
We have encountered issues with obtrusive interactions in conflicts with external factors such as dialogs.

In our opinion, there are two acceptable/required changes in this gem:
1. Stop to check result at the end of `select_bootstrap_date` because it's not the role of the helper
2. Stop to click on `//body` at the end of `select_date` and rely on [autoclose](https://bootstrap-datepicker.readthedocs.io/en/latest/options.html#autoclose)

Those changes will certainly break some test suites of current users, but it increases the compatibility of your gem.

Please give me some feedbacks!

## current behavior

Using Chrome, dialogs must be caught explicitely before making additional interaction with DOM:

```
  1) Bootstrap Datepicker with chrome_headless Boostrap 4.4 behaves like a datepicker alert/confirm callback fills in a datepicker while passing alert/confirm
     Failure/Error: fail if Date.parse(date_input.value) != value

     Selenium::WebDriver::Error::UnexpectedAlertOpenError:
       unexpected alert open: {Alert text : Date has changed}
         (Session info: chrome=87.0.4280.88)
     Shared Example Group: "a datepicker" called from ./spec/features/bootstrap_datepicker_spec.rb:87
     # 0   chromedriver                        0x0000000102901d79 chromedriver + 2510201
     # 1   chromedriver                        0x0000000102f6e743 chromedriver + 9246531
     # 2   chromedriver                        0x000000010273c623 chromedriver + 652835
     # 3   chromedriver                        0x00000001026edebb chromedriver + 331451
     # 4   chromedriver                        0x00000001026dee23 chromedriver + 269859
     # 5   chromedriver                        0x00000001026b800a chromedriver + 110602
     # 6   chromedriver                        0x00000001026b8fc7 chromedriver + 114631
     # 7   chromedriver                        0x00000001028d3429 chromedriver + 2319401
     # 8   chromedriver                        0x00000001028df53f chromedriver + 2368831
     # 9   chromedriver                        0x00000001028df150 chromedriver + 2367824
     # 10  chromedriver                        0x00000001028ba23b chromedriver + 2216507
     # 11  chromedriver                        0x00000001028dfa91 chromedriver + 2370193
     # 12  chromedriver                        0x00000001028c84f9 chromedriver + 2274553
     # 13  chromedriver                        0x00000001028f5f89 chromedriver + 2461577
     # 14  chromedriver                        0x00000001029073b3 chromedriver + 2532275
     # 15  libsystem_pthread.dylib             0x00007fff6a11a109 _pthread_start + 148
     # 16  libsystem_pthread.dylib             0x00007fff6a115b8b thread_start + 15
     # ./lib/capybara-bootstrap-datepicker.rb:53:in `select_bootstrap_date'
     # ./lib/capybara-bootstrap-datepicker.rb:21:in `select_date'
     # ./spec/features/bootstrap_datepicker_spec.rb:51:in `block (3 levels) in <top (required)>'
```

Also, when using `autoclose: true`, the additional click on `//body` made at the end of `select_date` is useless.

## expected behavior

We expect helper to be less obtrusive and more explicit:

```ruby
# click outside of input should be performed outside of "select_date", only if required
select_date Date.today, from: 'Label of date input with dialog callback', datepicker: :simple
first(:xpath, '//body').click
```

```ruby
# "select_date" should be usable in this form with dialogs handling
accept_alert do
  select_date Date.today, from: 'Label of date input with dialog callback', datepicker: :bootstrap
end
```