### PR TITLE
skip day selection new option

### DIFF
--- a/lib/capybara-bootstrap-datepicker.rb
+++ b/lib/capybara-bootstrap-datepicker.rb
@@ -18,7 +18,7 @@ module Capybara
 
       case datepicker
       when :bootstrap
-        select_bootstrap_date date_input, value
+        select_bootstrap_date date_input, value, format: format
       else
         select_simple_date date_input, value, format
       end
@@ -38,7 +38,7 @@ module Capybara
 
     # Selects a date by simulating human interaction with the datepicker
     # @param (see #select_simple_date)
-    def select_bootstrap_date(date_input, value)
+    def select_bootstrap_date(date_input, value, format: nil)
       date_input.click
 
       picker = Picker.new
@@ -48,9 +48,9 @@ module Capybara
 
       picker.find_year(value.year).click
       picker.find_month(value.month).click
-      picker.find_day(value.day).click
+      picker.find_day(value.day).click if format.nil? || format.include?('%d')
 
-      fail if Date.parse(date_input.value) != value
+      fail if (format.nil? ? Date.parse(date_input.value) : Date.strptime(date_input.value, format)) != value
     end
 
     private

--- a/lib/capybara-bootstrap-datepicker.rb
+++ b/lib/capybara-bootstrap-datepicker.rb
@@ -10,7 +10,7 @@ module Capybara
     # @param from [String, nil] the path to input field (required if `xpath` is nil)
     # @param xpath [String, nil] the xpath to input field (required if `from` is nil)
     # @param args [Hash] extra args to find the input field
-    def select_date(value, datepicker: :bootstrap, format: nil, from: nil, xpath: nil, **args)
+    def select_date(value, datepicker: :bootstrap, format: nil, from: nil, xpath: nil, skip_day: false, **args)
       fail "Must pass a hash containing 'from' or 'xpath'" if from.nil? && xpath.nil?
 
       value = value.respond_to?(:to_date) ? value.to_date : Date.parse(value)
@@ -18,7 +18,7 @@ module Capybara
 
       case datepicker
       when :bootstrap
-        select_bootstrap_date date_input, value, format: format
+        select_bootstrap_date date_input, value, format: format, skip_day: skip_day
       else
         select_simple_date date_input, value, format
       end
@@ -38,7 +38,7 @@ module Capybara
 
     # Selects a date by simulating human interaction with the datepicker
     # @param (see #select_simple_date)
-    def select_bootstrap_date(date_input, value, format: nil)
+    def select_bootstrap_date(date_input, value, format: nil, skip_day: false)
       date_input.click
 
       picker = Picker.new
@@ -48,7 +48,7 @@ module Capybara
 
       picker.find_year(value.year).click
       picker.find_month(value.month).click
-      picker.find_day(value.day).click if format.nil? || format.include?('%d')
+      picker.find_day(value.day).click if !skip_day
 
       fail if (format.nil? ? Date.parse(date_input.value) : Date.strptime(date_input.value, format)) != value
     end

--- a/lib/capybara-bootstrap-datepicker.rb
+++ b/lib/capybara-bootstrap-datepicker.rb
@@ -18,7 +18,7 @@ module Capybara
 
       case datepicker
       when :bootstrap
-        select_bootstrap_date date_input, value, format: format, skip_day: skip_day
+        select_bootstrap_date date_input, value, skip_day: skip_day
       else
         select_simple_date date_input, value, format
       end
@@ -38,7 +38,7 @@ module Capybara
 
     # Selects a date by simulating human interaction with the datepicker
     # @param (see #select_simple_date)
-    def select_bootstrap_date(date_input, value, format: nil, skip_day: false)
+    def select_bootstrap_date(date_input, value, skip_day: false)
       date_input.click
 
       picker = Picker.new
@@ -49,8 +49,6 @@ module Capybara
       picker.find_year(value.year).click
       picker.find_month(value.month).click
       picker.find_day(value.day).click if !skip_day
-
-      fail if (format.nil? ? Date.parse(date_input.value) : Date.strptime(date_input.value, format)) != value
     end
 
     private

--- a/spec/features/bootstrap-3.4.html
+++ b/spec/features/bootstrap-3.4.html
@@ -37,6 +37,14 @@
           <input id="registration-period-start-datapicker" class="form-control" type="text" name="cfp[start_date]">
         </span>
       </div>
+
+      <div class="form-group">
+        <label for="my-date-input-yyyy-mm">Label of my date input with YYYY-MM format</label>
+        <div class="input-group date my-date-input-yyyy-mm">
+          <input type="text" class="form-control" id="my-date-input-yyyy-mm">
+          <span class="input-group-addon"><i class="glyphicon glyphicon-th"></i></span>
+        </div>
+      </div>
     </form>
   </div>
   <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
@@ -46,6 +54,7 @@
     $('.input-group.default-date').datepicker({ format: 'yyyy-mm-dd' });
     $('.input-group.locale-date').datepicker({ format: 'yyyy-mm-dd', language: 'ja' });
     $('#registration-period-start-datapicker').datepicker({ format: 'yyyy-mm-dd', minDate : '2019-03-06', maxDate : '2019-03-12' });
+    $('.my-date-input-yyyy-mm').datepicker({ format: 'yyyy-mm', minViewMode: 1 });
   </script>
 </body>
 </html>

--- a/spec/features/bootstrap-4.4.html
+++ b/spec/features/bootstrap-4.4.html
@@ -37,6 +37,14 @@
           <input id="registration-period-start-datapicker" class="form-control" type="text" name="cfp[start_date]">
         </span>
       </div>
+
+      <div class="form-group">
+        <label for="my-date-input-yyyy-mm">Label of my date input with YYYY-MM format</label>
+        <div class="input-group date my-date-input-yyyy-mm">
+          <input type="text" class="form-control" id="my-date-input-yyyy-mm">
+          <span class="input-group-addon"><i class="glyphicon glyphicon-th"></i></span>
+        </div>
+      </div>
     </form>
   </div>
   <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
@@ -51,6 +59,8 @@
       minDate : '2019-03-06',
       maxDate : '2019-03-12'
     });
+
+    $('.my-date-input-yyyy-mm').datepicker({ format: 'yyyy-mm', minViewMode: 1 });
   </script>
 </body>
 </html>

--- a/spec/features/bootstrap_datepicker_spec.rb
+++ b/spec/features/bootstrap_datepicker_spec.rb
@@ -42,6 +42,22 @@ RSpec.shared_examples 'a datepicker' do
       expect(subject).to eq Date.today
     end
   end
+
+  context 'yyyy-mm format' do
+    subject { Date.strptime(find_field('Label of my date input with YYYY-MM format').value, '%Y-%m') }
+
+    let(:date)    { Date.new(Date.today.year, Date.today.month, 1) }
+
+    it 'fills in a date without day', js: true do
+      select_date date, from: 'Label of my date input with YYYY-MM format', datepicker: :simple
+      expect(subject).to eq date
+    end
+
+    it 'fills in a date without day on Bootstrap', js: true do
+      select_date date, from: 'Label of my date input with YYYY-MM format', datepicker: :bootstrap, format: '%Y-%m'
+      expect(subject).to eq date
+    end
+  end
 end
 
 RSpec.describe 'Bootstrap Datepicker', type: :feature do

--- a/spec/features/bootstrap_datepicker_spec.rb
+++ b/spec/features/bootstrap_datepicker_spec.rb
@@ -54,7 +54,7 @@ RSpec.shared_examples 'a datepicker' do
     end
 
     it 'fills in a date without day on Bootstrap', js: true do
-      select_date date, from: 'Label of my date input with YYYY-MM format', datepicker: :bootstrap, format: '%Y-%m'
+      select_date date, from: 'Label of my date input with YYYY-MM format', datepicker: :bootstrap, format: '%Y-%m', skip_day: true
       expect(subject).to eq date
     end
   end

--- a/spec/features/bootstrap_datepicker_spec.rb
+++ b/spec/features/bootstrap_datepicker_spec.rb
@@ -54,7 +54,7 @@ RSpec.shared_examples 'a datepicker' do
     end
 
     it 'fills in a date without day on Bootstrap', js: true do
-      select_date date, from: 'Label of my date input with YYYY-MM format', datepicker: :bootstrap, format: '%Y-%m', skip_day: true
+      select_date date, from: 'Label of my date input with YYYY-MM format', datepicker: :bootstrap, skip_day: true
       expect(subject).to eq date
     end
   end


### PR DESCRIPTION
Dear maintainer,

When using `select_bootstrap_date` with excluded day in format (for instance `YYYY-MM`), the helper fails when trying to find the day.
We expect a new option/enhancement to allow to skip this step.

I have made 3 commits implementing 3 different approaches:
1. Most implicit version, using existing `format` option
2. With new explicit option without breaking change, requiring to specify both `format` and `skip_day` options at once
3. With new explicit option and removed validation, based on #21 intention

My preference goes to latest commit because it clarifies the role of your helper by not expecting anything additional in the DOM, and stop using `Date.parse` which is currently not following the `format` option.

What do you think?

## current behavior

```
  1) Bootstrap Datepicker Boostrap 3.4 behaves like a datepicker yyyy-mm format fills in a date without day
     Failure/Error: days.find :xpath, day_xpath

     Capybara::ElementNotFound:
       Unable to find visible xpath "            .//*[contains(concat(' ', @class, ' '), ' day ')\n            and not(contains(concat(' ', @class, ' '), ' old '))\n            and not(contains(concat(' ', @class, ' '), ' new '))\n            and normalize-space(text())='6']\n" within #<Capybara::Node::Element tag="div" path="//HTML[1]/BODY[1]/DIV[2]/DIV[1]">
     Shared Example Group: "a datepicker" called from ./spec/features/bootstrap_datepicker_spec.rb:66
     # ./lib/capybara-bootstrap-datepicker.rb:103:in `find_day'
     # ./lib/capybara-bootstrap-datepicker.rb:51:in `select_bootstrap_date'
     # ./lib/capybara-bootstrap-datepicker.rb:21:in `select_date'
     # ./spec/features/bootstrap_datepicker_spec.rb:50:in `block (3 levels) in <top (required)>'
```

## expected behavior

Skip selection of date when `minViewMode` is not `0` (day) but is `1` (month)